### PR TITLE
Add AGENTS.md and fix all PHPStan errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         name: PHP ${{ matrix.php }} Symfony ${{ matrix.symfony-versions }} ${{ matrix.description }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - uses: actions/cache@v4
               with:
@@ -52,7 +52,7 @@ jobs:
 
             - name: Set composer cache directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache composer
               uses: actions/cache@v4
@@ -81,6 +81,6 @@ jobs:
                   
             - name: Upload coverage reports to Codecov
               if: matrix.coverage == 'xdebug'
-              uses: codecov/codecov-action@v4.0.1
+              uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a PHP Composer library (Symfony bundle) — not a standalone app. No services need to run.
+
+### Dev commands
+
+All commands are defined in `composer.json` scripts section:
+
+| Command | Purpose |
+|---------|---------|
+| `composer phpunit` | Run PHPUnit test suite (4 tests) |
+| `composer phpstan` | Run PHPStan static analysis (level max) |
+| `composer code-style` | Run PHP CodeSniffer (PSR-12 + Slevomat rules) |
+| `composer code-style-fix` | Auto-fix code style violations |
+| `composer dev-checks` | Run all checks (validate + phpstan + phpunit + code-style) |
+| `composer validate` | Validate composer.json |
+
+### Known issues
+
+- PHPStan has a pre-existing baseline mismatch: the ignored error pattern for `NodeDefinition::children()` in `phpstan-baseline.neon` no longer matches with current Symfony versions. This causes `composer phpstan` to exit with code 1. This is a repo issue, not an environment issue.
+- The `checkMissingIterableValueType` config option in `phpstan.neon.dist` is deprecated in newer PHPStan versions.
+
+### Environment notes
+
+- PHP 8.2 is installed from `ppa:ondrej/php` with extensions: xml, mbstring, curl, zip.
+- Composer is installed at `/usr/local/bin/composer`.
+- No Redis server needed — existing unit tests use Predis pure-PHP client without connecting to Redis.
+- No Docker, databases, or external services required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,9 @@ All commands are defined in `composer.json` scripts section:
 | `composer dev-checks` | Run all checks (validate + phpstan + phpunit + code-style) |
 | `composer validate` | Validate composer.json |
 
-### Known issues
+### Notes
 
-- PHPStan has a pre-existing baseline mismatch: the ignored error pattern for `NodeDefinition::children()` in `phpstan-baseline.neon` no longer matches with current Symfony versions. This causes `composer phpstan` to exit with code 1. This is a repo issue, not an environment issue.
-- The `checkMissingIterableValueType` config option in `phpstan.neon.dist` is deprecated in newer PHPStan versions.
+- PHPStan 1.x is currently used; an upgrade to 2.x is available but not yet applied.
 
 ### Environment notes
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,6 @@
 parameters:
 	ignoreErrors:
 	    -
-	        message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).#'
-	        count: 1
-	        path: ./src/DependencyInjection
-	    -
 	        message: '#.* of method BehatRedisContext\\Context\\RedisFixturesContext::loadFile\(\) expects array, mixed given.#'
 	        count: 1
 	        path: ./src/Context/RedisFixturesContext

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-	    -
-	        message: '#.* of method BehatRedisContext\\Context\\RedisFixturesContext::loadFile\(\) expects array, mixed given.#'
-	        count: 1
-	        path: ./src/Context/RedisFixturesContext

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,4 @@
-includes:
-    - phpstan-baseline.neon
-
 parameters:
     level: max
-    ignoreErrors:
-        -
-            identifier: missingType.iterableValue
     paths:
         - src/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,8 @@ includes:
 
 parameters:
     level: max
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        -
+            identifier: missingType.iterableValue
     paths:
         - src/

--- a/src/Context/RedisFixturesContext.php
+++ b/src/Context/RedisFixturesContext.php
@@ -47,13 +47,28 @@ class RedisFixturesContext implements Context
         $this->loadFixtures($fixtures);
     }
 
+    /**
+     * @param array<string> $fixtures
+     */
     private function loadFixtures(array $fixtures): void
     {
         foreach ($fixtures as $fixture) {
-            $this->loadFile(Yaml::parseFile($fixture));
+            /** @var mixed $parsed */
+            $parsed = Yaml::parseFile($fixture);
+
+            if (!is_array($parsed)) {
+                throw new InvalidArgumentException(
+                    sprintf('The "%s" fixture file must contain a YAML array.', $fixture)
+                );
+            }
+
+            $this->loadFile($parsed);
         }
     }
 
+    /**
+     * @param array<string, string|array<string, string>> $params
+     */
     private function loadFile(array $params): void
     {
         foreach ($params as $key => $value) {

--- a/src/DependencyInjection/BehatRedisContextExtension.php
+++ b/src/DependencyInjection/BehatRedisContextExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class BehatRedisContextExtension extends Extension
 {
     /**
-     * @param array<array> $configs
+     * @param array<array<string, mixed>> $configs
      *
      * {@inheritdoc}
      */
@@ -28,7 +28,7 @@ class BehatRedisContextExtension extends Extension
     }
 
     /**
-     * @param array<array> $config
+     * @param array<string, mixed> $config
      */
     private function loadBehatDatabaseContext(
         array $config,

--- a/tests/Context/RedisFixturesContextTest.php
+++ b/tests/Context/RedisFixturesContextTest.php
@@ -20,4 +20,22 @@ class RedisFixturesContextTest extends TestCase
 
         $redisFixtureContext->loadRedisFixtures('Test');
     }
+
+    public function testInvalidFixtureFileThrowsException(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/behat_redis_test_' . uniqid();
+        mkdir($tmpDir, 0777, true);
+        file_put_contents($tmpDir . '/scalar.yml', 'just a string');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('fixture file must contain a YAML array');
+
+        try {
+            $redisFixtureContext = new RedisFixturesContext(new Client(), $tmpDir);
+            $redisFixtureContext->loadRedisFixtures('scalar');
+        } finally {
+            unlink($tmpDir . '/scalar.yml');
+            rmdir($tmpDir);
+        }
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` for Cursor Cloud agents, fixes all PHPStan errors, and fixes CI workflow issues.

## Changes

### PHPStan fixes
- **`RedisFixturesContext`**: Added proper iterable type hints and `is_array()` validation for `Yaml::parseFile()`.
- **`BehatRedisContextExtension`**: Fixed `@param` types to include value types.
- **Removed `phpstan-baseline.neon`** — no longer needed since all errors are fixed.
- **Cleaned `phpstan.neon.dist`** — removed baseline include and deprecated `checkMissingIterableValueType` option.

### Test coverage
- Added `testInvalidFixtureFileThrowsException` to cover the new `is_array()` validation path in `RedisFixturesContext`.

### CI fixes
- Upgraded `actions/checkout` from `v2` to `v4` in both workflows (fixes Node.js 20 deprecation warnings).
- Upgraded `codecov/codecov-action` from `v4.0.1` to `v5` (fixes GPG EPIPE crash during coverage upload).
- Replaced deprecated `::set-output` with `$GITHUB_OUTPUT` environment file.

### Dev environment
- Created `AGENTS.md` with dev command reference and environment notes.

## Verification

All checks pass locally:
- `composer phpstan` — 0 errors, level max, zero ignored errors
- `composer phpunit` — 5 tests, 11 assertions, all pass
- `composer code-style` — all files pass
- `composer validate` — valid

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f13f754b-f11a-453e-a3da-a54ed647a72e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f13f754b-f11a-453e-a3da-a54ed647a72e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

